### PR TITLE
ci(release): run the release workflow on node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -224,7 +224,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/src/tests/phase1-integration.test.ts
+++ b/src/tests/phase1-integration.test.ts
@@ -187,7 +187,11 @@ describe('Phase 1 Integration Tests', () => {
 
       const recording = recorder.stopRecording();
 
-      expect(recording.steps[0].timestamp).toBe(0);
+      // The recorder anchors timestamps to startRecording(), so the first step is
+      // "close to 0" rather than exactly 0 — a sub-millisecond gap before the first
+      // recordSendInput can make it 1 on a slow runner. This matches the recorder's
+      // own contract asserted in TestRecorder.test.ts (steps[0] <= 5).
+      expect(recording.steps[0].timestamp).toBeLessThanOrEqual(5);
       expect(recording.steps[1].timestamp).toBeGreaterThan(40);
       expect(recording.steps[2].timestamp).toBeGreaterThan(
         recording.steps[1].timestamp


### PR DESCRIPTION
## Problem

The Release workflow fails on every push to `master` before it can cut a release:

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.
```

semantic-release's current major requires Node ≥ 22.14, but the `release`, `publish`,
and `publish-mcp-registry` jobs all pinned `node-version: '20'`. This is why the last
several release runs (including the one triggered by merging #81) failed without publishing.

## Fix

- Bump all three release-pipeline jobs to Node 22.
- De-flake `phase1-integration › should capture timing information correctly`: it asserted
  the first recorded step's timestamp is exactly `0`, but the recorder anchors timestamps to
  `startRecording()` so the first step is "close to 0" (its own unit test asserts `<= 5`).
  It flaked to `1` on a slow CI node. Aligned the assertion with the recorder's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)