### PR TITLE
fix(release): point semantic-release at the real github repository

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,6 @@
 {
   "branches": ["master"],
-  "repositoryUrl": "https://github.com/ooples/console-automation-mcp",
+  "repositoryUrl": "https://github.com/ooples/mcp-console-automation",
   "tagFormat": "v${version}",
   "plugins": [
     [

--- a/package.json
+++ b/package.json
@@ -134,12 +134,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ooples/console-automation-mcp.git"
+    "url": "git+https://github.com/ooples/mcp-console-automation.git"
   },
   "bugs": {
-    "url": "https://github.com/ooples/console-automation-mcp/issues"
+    "url": "https://github.com/ooples/mcp-console-automation/issues"
   },
-  "homepage": "https://github.com/ooples/console-automation-mcp#readme",
+  "homepage": "https://github.com/ooples/mcp-console-automation#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
## Problem

With the Node version fixed (#82), semantic-release gets further but still fails:

```
fatal: repository 'https://github.com/ooples/console-automation-mcp/' not found
```

`repositoryUrl` in `.releaserc.json` (and `repository`/`bugs`/`homepage` in
`package.json`) pointed at `ooples/console-automation-mcp`, which does not exist.
The actual repo is `ooples/mcp-console-automation`.

## Fix

Correct the GitHub repository URLs to `ooples/mcp-console-automation`. The npm
package name (`console-automation-mcp`) is intentional and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)