### PR TITLE
ci: skip PR checks on release-please release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   lint-and-format:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Lint and Format Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -79,6 +80,7 @@ jobs:
           node -e "require('./package.json')" || exit 1
 
   build:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -156,6 +158,7 @@ jobs:
           retention-days: 7
 
   test:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -253,6 +256,7 @@ jobs:
           "
 
   dependency-audit:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Dependency Audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -314,6 +318,7 @@ jobs:
           fi
 
   license-compliance:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: License Compliance
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   commitlint:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Lint Commit Messages
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   bundle-size:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Bundle Size Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -36,6 +37,7 @@ jobs:
           fi
 
   lint:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -53,6 +55,7 @@ jobs:
         run: npm run lint
 
   typecheck:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   unit-tests:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Unit Tests
     runs-on: ubuntu-latest
     strategy:
@@ -47,6 +48,7 @@ jobs:
         name: codecov-umbrella
 
   integration-tests:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Integration Tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -102,6 +104,7 @@ jobs:
       run: npm test -- --testPathPattern="test/integration/session-management\.test\.ts$" --testTimeout=45000
 
   ssh-tests:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: SSH Integration Tests
     runs-on: ubuntu-latest
     
@@ -160,6 +163,7 @@ jobs:
         SSH_TEST_KEY: ./test_key
 
   stress-tests:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Stress and Load Tests
     runs-on: ubuntu-latest
     
@@ -190,6 +194,7 @@ jobs:
         # Add any performance metric collection here
 
   security-scan:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Security Scan
     runs-on: ubuntu-latest
     
@@ -221,6 +226,7 @@ jobs:
       uses: github/codeql-action/analyze@v3
 
   docker-tests:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Docker Tests
     runs-on: ubuntu-latest
     
@@ -289,6 +295,7 @@ jobs:
         docker rm test-container
 
   cross-platform-tests:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Cross-Platform Tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -334,6 +341,7 @@ jobs:
   release-tests:
     name: Release Tests
     runs-on: ubuntu-latest
+    # Already push-to-main only, so it never runs on a (release-please) PR.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     
     needs: [unit-tests, integration-tests, ssh-tests, stress-tests, security-scan]
@@ -370,6 +378,7 @@ jobs:
   benchmark-tests:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
+    # Schedule/dispatch only, so it never runs on a (release-please) PR.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
@@ -412,7 +421,8 @@ jobs:
   notify-results:
     name: Notify Results
     runs-on: ubuntu-latest
-    if: always()
+    # Runs even when upstream jobs fail, but still skip it on a (release-please) PR.
+    if: ${{ always() && !startsWith(github.head_ref, 'release-please--') }}
     needs: [unit-tests, integration-tests, ssh-tests, stress-tests, security-scan, docker-tests]
     
     steps:


### PR DESCRIPTION
## Problem
When a feature PR merges, it has already passed the full CI (build, lint, 3-node test matrix). release-please then opens a **Release PR** that only bumps `package.json` version + appends `CHANGELOG.md` — and that Release PR **re-runs the exact same checks**, which can't fail on a version/changelog-only diff. Pure redundancy (CI minutes + noise).

## Fix
Guard every PR-triggered job across `ci.yml`, `commitlint.yml`, `quality-gates.yml`, and `test.yml` with:
```yaml
if: ${{ !startsWith(github.head_ref, 'release-please--') }}
```
- On a **release-please PR** (`head_ref` = `release-please--…`) → every job skips.
- On **normal PRs** and on **push** (`head_ref` empty) → jobs run as before.
- Jobs already scoped to push/schedule (`release-tests`, `benchmark-tests`) are left unchanged; `notify-results` keeps `always()` and ANDs the guard in.

## Why it's safe
- CI is **not a required status check** here — merges gate on approving reviews, so skipped checks don't block the Release PR.
- The release workflow checks out the tag and `npm run build`s before publishing, so the released artifact is still built fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)