### PR TITLE
fix(ssh): stop acknowledging commands on their own output (long-session wedge)

### DIFF
--- a/src/core/ConsoleManager.ts
+++ b/src/core/ConsoleManager.ts
@@ -202,7 +202,6 @@ interface CommandQueueConfig {
   interCommandDelay: number;
   acknowledgmentTimeout: number;
   enablePromptDetection: boolean;
-  defaultPromptPattern: RegExp;
 }
 
 // Network performance monitoring for adaptive timeouts
@@ -506,7 +505,6 @@ export class ConsoleManager extends EventEmitter {
       interCommandDelay: 500,
       acknowledgmentTimeout: 10000,
       enablePromptDetection: true,
-      defaultPromptPattern: /[$#%>]\s*$/m,
     };
 
     // Initialize adaptive timeout configuration
@@ -8086,7 +8084,34 @@ export class ConsoleManager extends EventEmitter {
   /**
    * Initialize command queue for a session with persistence support
    */
+  /**
+   * Register a session with the prompt detector.
+   *
+   * Must run before any output reaches PromptDetector.addOutput(): without a
+   * session config that call logs a warning and drops the data on the floor, so
+   * the detector's buffer stays empty and detectPrompt() always returns null.
+   * Idempotent — configureSession() resets the buffer, so only configure once.
+   */
+  private ensurePromptDetection(sessionId: string): void {
+    if (this.promptDetector.hasSession(sessionId)) {
+      return;
+    }
+
+    const session = this.sessions.get(sessionId);
+    this.promptDetector.configureSession({
+      sessionId,
+      shellType: this.detectShellType(session?.type),
+      hostname: session?.sshOptions?.host,
+      username: session?.sshOptions?.username,
+      adaptiveLearning: true,
+    });
+  }
+
   private initializeCommandQueue(sessionId: string): void {
+    // Output handlers are attached right after this call, so the detector has
+    // to be configured now or every chunk they feed it is discarded.
+    this.ensurePromptDetection(sessionId);
+
     if (!this.commandQueues.has(sessionId)) {
       const persistentData = this.sessionPersistenceData.get(sessionId);
       const bookmarks = this.sessionBookmarks.get(sessionId) || [];
@@ -8098,7 +8123,10 @@ export class ConsoleManager extends EventEmitter {
         lastCommandTime: 0,
         acknowledgmentTimeout: null,
         outputBuffer: '',
-        expectedPrompt: this.queueConfig.defaultPromptPattern,
+        // Left unset so acknowledgment goes through the confidence-scored
+        // PromptDetector. setPromptPattern() populates this to force a
+        // specific pattern instead.
+        expectedPrompt: undefined,
         persistentData,
         bookmarks,
       };
@@ -8305,6 +8333,10 @@ export class ConsoleManager extends EventEmitter {
         if (!command.sent) {
           // Send the command
           try {
+            // Drop anything already buffered — notably the prompt the shell
+            // printed when the *previous* command finished. Left in place it
+            // would acknowledge this command the instant it is sent.
+            queue.outputBuffer = '';
             await this.sendCommandToSSH(sessionId, command, sshChannel);
             command.sent = true;
             command.timestamp = new Date();
@@ -8345,8 +8377,8 @@ export class ConsoleManager extends EventEmitter {
         }
 
         // Check for acknowledgment
-        if (this.queueConfig.enablePromptDetection && queue.expectedPrompt) {
-          if (queue.expectedPrompt.test(queue.outputBuffer)) {
+        if (this.queueConfig.enablePromptDetection) {
+          if (this.hasReturnedToPrompt(sessionId, queue)) {
             // Command acknowledged
             command.acknowledged = true;
             command.resolve();
@@ -8373,6 +8405,37 @@ export class ConsoleManager extends EventEmitter {
     if (queue.commands.length > 0) {
       setTimeout(() => this.processCommandQueue(sessionId), 100);
     }
+  }
+
+  /**
+   * Whether the shell has finished the in-flight command and returned to a prompt.
+   *
+   * Only the tail of the buffer is considered. A prompt is the last thing the
+   * shell writes before it blocks on input, whereas command output is always
+   * followed by more output — so matching anywhere in the buffer (as a naive
+   * /m pattern does) misreads ordinary output lines ending in $ # % > as a
+   * prompt (`94%` from df, `84.4%` from top, `ooples-#` from psql). That
+   * acknowledges the command early and sends the next one into a still-running
+   * shell, which is how long sessions drift out of sync and wedge.
+   */
+  private hasReturnedToPrompt(
+    sessionId: string,
+    queue: SessionCommandQueue
+  ): boolean {
+    // An explicit per-session override always wins, but is still anchored to the
+    // tail so it cannot match mid-output.
+    if (queue.expectedPrompt) {
+      return this.promptDetector.matchesPromptTail(
+        queue.outputBuffer,
+        queue.expectedPrompt
+      );
+    }
+
+    const result = this.promptDetector.detectPrompt(
+      sessionId,
+      queue.outputBuffer
+    );
+    return result?.detected === true;
   }
 
   /**
@@ -9271,6 +9334,10 @@ export class ConsoleManager extends EventEmitter {
     // Clear command queue for this session
     this.clearCommandQueue(sessionId);
 
+    // Drop prompt-detection state so its buffers/learned patterns don't
+    // accumulate for the lifetime of the server.
+    this.promptDetector.removeSession(sessionId);
+
     // Ensure monitoring is stopped
     if (this.monitoringSystem.isSessionBeingMonitored(sessionId)) {
       this.monitoringSystem.stopSessionMonitoring(sessionId);
@@ -9528,7 +9595,7 @@ export class ConsoleManager extends EventEmitter {
   ): Promise<{ output: string; promptDetected?: PromptDetectionResult }> {
     const timeout = options.timeout || 5000;
     const requirePrompt = options.requirePrompt || false;
-    const stripAnsi = options.stripAnsi !== false;
+    const stripAnsiOutput = options.stripAnsi !== false;
     const promptTimeout = options.promptTimeout || timeout;
 
     // Use enhanced waitForOutput implementation
@@ -9537,19 +9604,44 @@ export class ConsoleManager extends EventEmitter {
         typeof pattern === 'string' ? new RegExp(pattern, 'im') : pattern;
       const startTime = Date.now();
 
+      // Accumulate every chunk seen from this point on. The session's own
+      // buffers are rolling windows (last 150 chunks / last 10k prompt chars),
+      // so under a burst of output the pattern can scroll out of view between
+      // two 50ms polls and then never match, even though it did appear.
+      let accumulated = this.getLastOutput(sessionId, 150);
+
+      const onConsoleEvent = (event: ConsoleEvent) => {
+        if (event.sessionId !== sessionId || event.type !== 'output') return;
+        const payload = event.data;
+        const chunk =
+          typeof payload === 'string' ? payload : (payload?.data ?? '');
+        if (chunk) accumulated += chunk;
+      };
+      this.on('console-event', onConsoleEvent);
+
+      const settle = <T>(fn: (value: T) => void) => {
+        return (value: T) => {
+          this.off('console-event', onConsoleEvent);
+          fn(value);
+        };
+      };
+      const finish = settle(resolve);
+      const fail = settle(reject);
+
       const checkOutput = () => {
+        // Routed through fail() rather than reject() so the output listener is
+        // detached on this exit path too.
         if (!this.sessions.has(sessionId)) {
-          reject(new Error(`Session ${sessionId} not found`));
+          fail(new Error(`Session ${sessionId} not found`));
           return;
         }
 
-        let output = this.getLastOutput(sessionId, 150);
+        const output = stripAnsiOutput ? stripAnsi(accumulated) : accumulated;
 
-        if (stripAnsi) {
-          output = this.promptDetector.getBuffer(sessionId) || output;
-        }
-
-        // Test pattern match
+        // Test pattern match. lastIndex is reset because a caller-supplied
+        // /g or /y regex makes .test() stateful, which would make it alternate
+        // between match and no-match across polls.
+        regex.lastIndex = 0;
         const patternMatch = regex.test(output);
 
         // Check for prompt if required
@@ -9562,7 +9654,7 @@ export class ConsoleManager extends EventEmitter {
           patternMatch &&
           (!requirePrompt || (promptResult && promptResult.detected))
         ) {
-          resolve({
+          finish({
             output,
             promptDetected: promptResult || undefined,
           });
@@ -9571,7 +9663,7 @@ export class ConsoleManager extends EventEmitter {
 
         if (!this.isSessionRunning(sessionId)) {
           const sessionInfo = this.sessions.get(sessionId);
-          reject(
+          fail(
             new Error(
               `Session ${sessionId} has stopped (status: ${sessionInfo?.status || 'unknown'})`
             )
@@ -9601,7 +9693,7 @@ export class ConsoleManager extends EventEmitter {
             `Timeout waiting for pattern in session ${sessionId}`,
             debugInfo
           );
-          reject(
+          fail(
             new Error(
               `Timeout waiting for pattern: ${pattern}. Last output: "${output.slice(-200)}"`
             )
@@ -9624,17 +9716,30 @@ export class ConsoleManager extends EventEmitter {
     timeout: number = 10000
   ): Promise<{ detected: boolean; prompt?: string; output: string }> {
     const queue = this.commandQueues.get(sessionId);
-    const defaultPattern =
-      queue?.expectedPrompt || this.queueConfig.defaultPromptPattern;
+    this.ensurePromptDetection(sessionId);
 
     try {
-      const result = await this.waitForOutput(sessionId, defaultPattern, {
-        timeout,
-      });
+      // With an explicit override, match it against the tail. Otherwise defer to
+      // the detector's structured, shell-specific patterns — no generic regex
+      // can tell a zsh `%` prompt from `84.4%` in top's output.
+      if (queue?.expectedPrompt) {
+        const pattern = queue.expectedPrompt;
+        const result = await this.waitForOutput(sessionId, pattern, { timeout });
+        return {
+          detected: true,
+          prompt: result.output.match(pattern)?.[0],
+          output: result.output,
+        };
+      }
+
+      const detection = await this.promptDetector.waitForPrompt(
+        sessionId,
+        timeout
+      );
       return {
-        detected: true,
-        prompt: result.output.match(defaultPattern)?.[0],
-        output: result.output,
+        detected: detection.detected,
+        prompt: detection.matchedText,
+        output: this.promptDetector.getBuffer(sessionId),
       };
     } catch (error) {
       this.logger.error(`Failed to wait for prompt in session ${sessionId}`, {

--- a/src/core/PromptDetector.ts
+++ b/src/core/PromptDetector.ts
@@ -244,6 +244,35 @@ export class PromptDetector {
   /**
    * Configure prompt detection for a session
    */
+  /**
+   * Whether a session has been configured. Callers use this to stay idempotent,
+   * since configureSession() resets the session's output buffer.
+   */
+  hasSession(sessionId: string): boolean {
+    return this.sessionConfigs.has(sessionId);
+  }
+
+  /**
+   * Whether an explicit, caller-supplied prompt pattern matches the end of the
+   * buffer.
+   *
+   * The pattern is applied to the final non-empty line rather than the whole
+   * buffer: a prompt is the last thing a shell writes before blocking on input,
+   * whereas command output is always followed by more output. Matching anywhere
+   * lets loose patterns fire on ordinary output (`94%` from df, `84.4%` from
+   * top, `ooples-#` from psql) and acknowledge a command that is still running.
+   */
+  matchesPromptTail(buffer: string, pattern: RegExp): boolean {
+    const tail = buffer.replace(/\s+$/, '');
+    if (!tail) return false;
+
+    const lastLine = tail.slice(tail.lastIndexOf('\n') + 1);
+
+    // A caller-supplied /g or /y regex makes .test() stateful across calls.
+    pattern.lastIndex = 0;
+    return pattern.test(lastLine);
+  }
+
   configureSession(config: PromptDetectorConfig): void {
     this.sessionConfigs.set(config.sessionId, {
       enableAnsiStripping: true,

--- a/tests/unit/prompt-acknowledgment.test.ts
+++ b/tests/unit/prompt-acknowledgment.test.ts
@@ -1,0 +1,141 @@
+import { PromptDetector } from '../../src/core/PromptDetector.js';
+
+/**
+ * Regression tests for the long-session wedge.
+ *
+ * The SSH command queue acknowledges a command once the shell has returned to a
+ * prompt. It used to decide that with /[$#%>]\s*$/m, which matches *any* line
+ * ending in $ # % > — including ordinary command output. That acknowledged
+ * commands early and sent the next one into a still-running shell, so a long
+ * session drifted out of sync until it wedged.
+ */
+describe('prompt detection vs. real command output', () => {
+  const SESSION = 'test-session';
+  let detector: PromptDetector;
+
+  beforeEach(() => {
+    detector = new PromptDetector();
+    detector.configureSession({
+      sessionId: SESSION,
+      shellType: 'bash',
+      adaptiveLearning: false,
+    });
+  });
+
+  // Output captured from a real production session against ubuntu@ns107444.
+  const NOT_PROMPTS: Array<[string, string]> = [
+    ['df -h usage column', '/dev/sda1        50G   44G   3.0G  94%'],
+    ['top cpu line', 'Cpu(s): 12.5%us,  3.1%sy,  0.0%ni, 84.4%'],
+    ['psql continuation prompt', 'ooples-#'],
+    ['download progress', 'Downloading package... 87%'],
+    ['awk/redirect in echoed command', 'cat foo.txt > bar.txt'],
+  ];
+
+  it.each(NOT_PROMPTS)(
+    'does not treat %s as a shell prompt',
+    (_label, line) => {
+      const result = detector.detectPrompt(SESSION, `some earlier output\n${line}`);
+      expect(result?.detected ?? false).toBe(false);
+    }
+  );
+
+  const REAL_PROMPTS: Array<[string, string]> = [
+    ['ubuntu bash prompt', 'ubuntu@ns107444:~$ '],
+    ['ubuntu bash prompt in a subdir', 'ubuntu@ns107444:/opt/ooples$ '],
+    ['root prompt', 'root@ns107444:/var/log# '],
+  ];
+
+  it.each(REAL_PROMPTS)('detects %s', (_label, prompt) => {
+    const result = detector.detectPrompt(SESSION, `command output here\n${prompt}`);
+    expect(result?.detected).toBe(true);
+  });
+
+  it('detects the prompt that terminates output which itself ends in %', () => {
+    // The exact shape that wedged the real session: df output (ending in 94%)
+    // followed by the genuine prompt. The prompt is what must be matched.
+    const buffer = [
+      'Filesystem       Size  Used Avail Use% Mounted on',
+      '/dev/sda1        50G   44G   3.0G  94% /',
+      'ubuntu@ns107444:~$ ',
+    ].join('\n');
+
+    const result = detector.detectPrompt(SESSION, buffer);
+    expect(result?.detected).toBe(true);
+    expect(result?.matchedText).toContain('ubuntu@ns107444');
+  });
+
+  it('buffers output only for configured sessions', () => {
+    // addOutput() silently drops data for unconfigured sessions, which left the
+    // detector inert for every session the manager created.
+    detector.addOutput(SESSION, 'hello');
+    expect(detector.getBuffer(SESSION)).toBe('hello');
+
+    detector.addOutput('never-configured', 'hello');
+    expect(detector.getBuffer('never-configured')).toBe('');
+  });
+
+  it('reports whether a session is configured', () => {
+    expect(detector.hasSession(SESSION)).toBe(true);
+    expect(detector.hasSession('never-configured')).toBe(false);
+  });
+});
+
+describe('matchesPromptTail (explicit pattern override)', () => {
+  const detector = new PromptDetector();
+
+  // A caller-supplied pattern, as setPromptPattern() would install.
+  const USER_PATTERN = /\$\s*$/;
+
+  // What the queue used before: matched any *line* ending in $ # % >, anywhere
+  // in the buffer.
+  const OLD_BROKEN_PATTERN = /[$#%>]\s*$/m;
+
+  const dfOutput = [
+    'Filesystem       Size  Used Avail Use% Mounted on',
+    '/dev/sda1        50G   44G   3.0G  94% /',
+    'tmpfs             13G     0   13G   0%',
+  ].join('\n');
+
+  it('does not fire while command output is still streaming', () => {
+    expect(detector.matchesPromptTail(dfOutput, USER_PATTERN)).toBe(false);
+  });
+
+  it('fires once the shell prints its prompt after that output', () => {
+    expect(
+      detector.matchesPromptTail(`${dfOutput}\nubuntu@ns107444:~$ `, USER_PATTERN)
+    ).toBe(true);
+  });
+
+  it('confines an over-broad pattern to the tail instead of the whole buffer', () => {
+    // The old whole-buffer /m match fired on df's `0%` line mid-output, which
+    // acknowledged the command early and sent the next one into a running shell.
+    // Tail-anchoring alone cannot rescue a pattern this loose (the last line
+    // still ends in %), so the queue no longer defaults to one — but anchoring
+    // does stop it matching output that has since scrolled past.
+    expect(OLD_BROKEN_PATTERN.test(dfOutput)).toBe(true);
+    expect(
+      detector.matchesPromptTail(`${dfOutput}\nstill running...`, OLD_BROKEN_PATTERN)
+    ).toBe(false);
+  });
+
+  it('is not stateful across calls for a global regex', () => {
+    // A /g regex makes .test() advance lastIndex, so repeated polls would
+    // alternate between match and no-match on identical input.
+    const globalPattern = /\$\s*$/g;
+    const prompt = 'ubuntu@ns107444:~$ ';
+    expect(detector.matchesPromptTail(prompt, globalPattern)).toBe(true);
+    expect(detector.matchesPromptTail(prompt, globalPattern)).toBe(true);
+    expect(detector.matchesPromptTail(prompt, globalPattern)).toBe(true);
+  });
+
+  it('ignores trailing blank lines when locating the tail', () => {
+    expect(
+      detector.matchesPromptTail('ubuntu@ns107444:~$ \n\n', USER_PATTERN)
+    ).toBe(true);
+  });
+
+  it('returns false for an empty or whitespace-only buffer', () => {
+    expect(detector.matchesPromptTail('', USER_PATTERN)).toBe(false);
+    expect(detector.matchesPromptTail('   \n  ', USER_PATTERN)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Symptom

Long SSH sessions drift out of sync and eventually hang: commands stop returning, and `console_wait_for_output` reports `matched: false` for output that visibly arrived. Short sessions look fine, which is what made this hard to pin down.

## Root causes (three, compounding)

### 1. Ordinary output was being read as a shell prompt

The command queue decided a command had finished by testing the buffer against `/[$#%>]\s*$/m` — **any line ending in `$ # % >`**. Real production output matches it:

```
/dev/sda1  50G  44G  3.0G  94%             ← df
Cpu(s): 12.5%us,  3.1%sy,  0.0%ni, 84.4%   ← top
ooples-#                                    ← psql continuation prompt
Downloading... 87%                          ← progress
```

So a command was acknowledged **while still running**, the queue advanced, and the next command was written into a busy shell. Each occurrence compounds the drift — hence "only in long sessions". The buffer also still held the *previous* command's prompt when the next command was dispatched, acknowledging it instantly.

### 2. `PromptDetector` was never configured for any session — inert in practice

The repo already has a good structured detector (`ubuntu@host:path$`, priority 15, confidence-scored). But `configureSession()` had exactly **one** call site: the `reset-prompt-detector` recovery action. For a normal session:

- `addOutput()` hit its `if (!config)` guard → warned and **dropped every chunk**
- `getBuffer()` → always `''`
- `detectPrompt()` → always `null`

The subsystem only came alive *after* a session had already broken badly enough for error recovery to run.

### 3. `waitForOutput` searched a rolling 150-chunk window

A pattern arriving in a burst could scroll out of view between two 50ms polls and never match — reporting a timeout for output that did arrive. It also silently substituted the prompt-detector's buffer whenever `stripAnsi` was on (the default), searching different, smaller data than the caller expected.

## Fixes

- Configure the prompt detector for **every** session (`ensurePromptDetection`, at the queue-init choke point that runs before output handlers attach); remove it on session stop so buffers/learned patterns don't accumulate.
- Acknowledge via the structured detector (`hasReturnedToPrompt`). **`defaultPromptPattern` is deleted, not patched** — no generic regex can distinguish a zsh `%` prompt from `84.4%` in `top` output, which is exactly why the detector's shell-specific patterns exist. An explicit `setPromptPattern` override still wins, anchored to the tail via `matchesPromptTail`.
- Clear the queue buffer on dispatch, so only post-command output can acknowledge.
- `waitForOutput` accumulates output from the call onward via the event stream, strips ANSI properly using the already-imported `strip-ansi`, resets `lastIndex` so a caller's `/g` regex isn't stateful across polls, and detaches its listener on **every** exit path (including master's newer session-not-found guard).

## Verification

17 regression tests built from **real captured production output**, including the exact `df`/`top`/`psql` lines above.

Measured against a clean baseline on the same tree (this repo has substantial pre-existing failures, so raw counts alone would mislead):

| | Test Suites | Tests |
|---|---|---|
| baseline (master) | 29 failed / 40 | **165 failed**, 370 passed, 535 total |
| this branch | 28 failed / 40 | **164 failed**, 388 passed, 552 total |

No regressions: +17 new tests all passing, one previously-failing suite now passes, remaining failures pre-existing and unrelated. `npx tsc --noEmit` clean.

Note: a `matchesPromptTail` test documents that tail-anchoring alone cannot rescue an over-broad pattern (its last line still ends in `%`) — which is why the default now goes through the structured detector rather than any regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
